### PR TITLE
Beat Saber 1.8.0 Update (and some other stuff)

### DIFF
--- a/DiscordCore/DiscordAPI/Core.cs
+++ b/DiscordCore/DiscordAPI/Core.cs
@@ -694,6 +694,7 @@ namespace Discord
 
         public ResultException(Result result) : base(result.ToString())
         {
+            Result = result;
         }
     }
 

--- a/DiscordCore/DiscordClient.cs
+++ b/DiscordCore/DiscordClient.cs
@@ -18,17 +18,12 @@ namespace DiscordCore
         internal static event ActivityInviteHandler OnActivityInvite;
         internal static event ActivitySpectateHandler OnActivitySpectate;
 
-        public static long CurrentAppID { get; private set; }
+        public static long CurrentAppID { get; private set; } = -1;
         public static bool Enabled { get; private set; }
         private static long _appIdWhenDisabled;
         private static Discord.Discord _discordClient;
         private static Dictionary<LogLevel, Logger.Level> _logLevels = new Dictionary<LogLevel, Logger.Level>() { { LogLevel.Debug, Logger.Level.Debug }, { LogLevel.Info, Logger.Level.Info }, { LogLevel.Warn, Logger.Level.Warning }, { LogLevel.Error, Logger.Level.Error } };
 
-        static DiscordClient()
-        {
-            CurrentAppID = -1;
-            ChangeAppID(DefaultAppID);
-        }
         private static void LinkActivityEvents(ActivityManager activityManager)
         {
             activityManager.OnActivityInvite += OnActivityInvite;
@@ -138,28 +133,8 @@ namespace DiscordCore
                 }
                 catch (Discord.ResultException e)
                 {
-                    if (e.Result != Result.NotRunning && e.Result != Result.InternalError)
-                    {
-                        Plugin.log.Error($"Changing AppID: {e.Message}");
-                        Plugin.log.Debug(e);
-                    }
-                    else
-                    {
-#if DEBUG
-                        Plugin.log.Debug(e);
-#endif
-                        Plugin.log.Info("Discord is not running.");
-                    }
                     Disable(true);
-                    DiscordManager.active = false;
-                    DiscordManager.SetDeactivationReasonFromException(e);
-                }
-                catch (Exception e)
-                {
-                    Plugin.log.Debug(e);
-                    Disable(true);
-                    DiscordManager.active = false;
-                    DiscordManager.SetDeactivationReasonFromException(e);
+                    throw;
                 }
             }
         }

--- a/DiscordCore/DiscordCore.csproj
+++ b/DiscordCore/DiscordCore.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG;UNITY_STANDALONE</DefineConstants>
@@ -23,7 +23,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE;UNITY_STANDALONE</DefineConstants>
@@ -31,6 +31,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="HMLib, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\HMLib.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="IPA.Loader, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>

--- a/DiscordCore/DiscordInstance.cs
+++ b/DiscordCore/DiscordInstance.cs
@@ -54,7 +54,7 @@ namespace DiscordCore
 
         public void DestroyInstance()
         {
-            DiscordManager.Instance.DestroyInstance(this);
+            DiscordManager.instance.DestroyInstance(this);
         }
 
         internal void CallActivityJoin(string secret) { OnActivityJoin?.Invoke(secret); }

--- a/DiscordCore/Plugin.cs
+++ b/DiscordCore/Plugin.cs
@@ -8,65 +8,16 @@ using UnityEngine.SceneManagement;
 
 namespace DiscordCore
 {
-    public class Plugin : IBeatSaberPlugin
+    [Plugin(RuntimeOptions.SingleStartInit)]
+    public class Plugin
     {
         internal static IPA.Logging.Logger log;
 
-        public static bool active = true;
-        public static string deactivationReason;
-
-        private static float lastCheckTime;
-
+        [Init]
         public void Init(IPA.Logging.Logger log)
         {
             Plugin.log = log;
-        }
-
-        public void OnActiveSceneChanged(Scene prevScene, Scene nextScene)
-        {
-
-        }
-
-        public void OnApplicationQuit()
-        {
-
-        }
-
-        public void OnApplicationStart()
-        {
-
-        }
-
-        public void OnFixedUpdate()
-        {
-
-        }
-
-        public void OnSceneLoaded(Scene scene, LoadSceneMode sceneMode)
-        {
-
-        }
-
-        public void OnSceneUnloaded(Scene scene)
-        {
-
-        }
-
-        public void OnUpdate()
-        {
-            if (active)
-            {
-                DiscordManager.Instance.Update();
-                DiscordClient.RunCallbacks();
-            }
-            else
-            {
-                if (UnityEngine.Time.time - lastCheckTime >= 10f)
-                {
-                    lastCheckTime = UnityEngine.Time.time;
-                    log.Error("DiscordCore is not active! Reason: " + deactivationReason);
-                }
-            }
+            DiscordManager manager = DiscordManager.instance;
         }
     }
 }

--- a/DiscordCore/manifest.json
+++ b/DiscordCore/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "https://github.com/nike4613/BSIPA-MetadataFileSchema/master/Schema.json",
     "author": "andruzzzhka",
     "description": "A plugin for Discord integration in Beat Saber",
-    "gameVersion": "1.6.2",
+    "gameVersion": "1.8.0",
     "id": "DiscordCore",
     "name": "DiscordCore",
     "version": "1.0.0",


### PR DESCRIPTION
It's not my prettiest work (and I'm still bad at GitHub so this is more than just a 1.8.0 update), but everything appears functional. I haven't been able to do a real test since 1.8.0 also broke some things in Multiplayer.
* Made DiscordManager a PersistentSingleton and rolled Plugin.cs's OnUpdate and status fields into it.
* Reconnects to Discord if Discord is opened (or closed and opened) while the game is running.
* Reduces log spam by not logging repeat messages.
* Small fix to DiscordAPI.Core.cs's ResultException so that the Result field is assigned the result.
* Changed project's PDB type to portable so that BSIPA logs the File/Line info.